### PR TITLE
Add support for setting a custom ARM frequency

### DIFF
--- a/Drivers/ConfigDxe/ConfigDxe.c
+++ b/Drivers/ConfigDxe/ConfigDxe.c
@@ -148,6 +148,14 @@ SetupVariables (
   }
 
   Size = sizeof (UINT32);
+  Status = gRT->GetVariable(L"CustomCpuClockRate",
+                            &gConfigDxeFormSetGuid,
+                            NULL,  &Size, &Var32);
+  if (EFI_ERROR (Status)) {
+    PcdSet32 (PcdCustomCpuClockRate, PcdGet32 (PcdCustomCpuClockRate));
+  }
+
+  Size = sizeof (UINT32);
   Status = gRT->GetVariable(L"SdIsArasan",
                             &gConfigDxeFormSetGuid,
                             NULL,  &Size, &Var32);
@@ -249,6 +257,7 @@ ApplyVariables (
   UINTN Gpio48Group;
   EFI_STATUS Status;
   UINT32 CpuClock = PcdGet32 (PcdCpuClock);
+  UINT32 CustomCpuClockRate = PcdGet32 (PcdCustomCpuClockRate);
   UINT32 Rate = 0;
 
   if (CpuClock != 0) {
@@ -262,6 +271,8 @@ ApplyVariables (
         DEBUG((EFI_D_ERROR, "Couldn't get the max CPU speed, leaving as is: %r\n",
                Status));
       }
+    } else if (CpuClock == 3) {
+      Rate = CustomCpuClockRate * 1000000;
     } else {
       Rate = 600 * 1000000;
     }
@@ -269,7 +280,7 @@ ApplyVariables (
 
   if (Rate != 0) {
     DEBUG((EFI_D_INFO, "Setting CPU speed to %uHz\n", Rate));
-    Status = mFwProtocol->SetClockRate(RPI_FW_CLOCK_RATE_ARM, Rate);
+    Status = mFwProtocol->SetClockRate(RPI_FW_CLOCK_RATE_ARM, Rate, 1);
     if (Status != EFI_SUCCESS) {
       DEBUG((EFI_D_ERROR, "Couldn't set the CPU speed: %r\n",
              Status));

--- a/Drivers/ConfigDxe/ConfigDxeHii.uni
+++ b/Drivers/ConfigDxe/ConfigDxeHii.uni
@@ -54,6 +54,10 @@
 #string STR_CHIPSET_CLOCK_CPU_NA     #language en-US "Don't Override"
 #string STR_CHIPSET_CLOCK_CPU_600MHZ #language en-US "Min (600MHz)"
 #string STR_CHIPSET_CLOCK_CPU_MAX    #language en-US "Max"
+#string STR_CHIPSET_CLOCK_CPU_CUSTOM #language en-US "Custom"
+
+#string STR_CHIPSET_CUSTOM_CPU_CLOCK_RATE_PROMPT #language en-US "CPU Clock Rate (MHz)"
+#string STR_CHIPSET_CUSTOM_CPU_CLOCK_RATE_HELP   #language en-US "Adjust the CPU speed.\nMin value: 100 MHz\nMax value: 1600 MHz\n\nWarning! Overclocking can make the system unbootable!"
 
 #string STR_CHIPSET_SD_PROMPT        #language en-US "uSD Routing"
 #string STR_CHIPSET_SD_HELP          #language en-US "Choose host controller to drive uSD slot"

--- a/Drivers/ConfigDxe/ConfigDxeHii.vfr
+++ b/Drivers/ConfigDxe/ConfigDxeHii.vfr
@@ -91,6 +91,10 @@ typedef struct {
 } CHIPSET_CPU_CLOCK_VARSTORE_DATA;
 
 typedef struct {
+  UINT32 Clock;
+} CHIPSET_CUSTOM_CPU_CLOCK_RATE_VARSTORE_DATA;
+
+typedef struct {
   /*
    * 0 - uSD slot routed to Broadcom SDHOST.
    * 1 - uSD slot routed to Arasan SDHCI.
@@ -173,6 +177,11 @@ formset
     efivarstore CHIPSET_CPU_CLOCK_VARSTORE_DATA,
       attribute = EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_NON_VOLATILE,
       name  = CpuClock,
+      guid  = CONFIGDXE_FORM_SET_GUID;
+
+    efivarstore CHIPSET_CUSTOM_CPU_CLOCK_RATE_VARSTORE_DATA,
+      attribute = EFI_VARIABLE_BOOTSERVICE_ACCESS | EFI_VARIABLE_RUNTIME_ACCESS | EFI_VARIABLE_NON_VOLATILE,
+      name  = CustomCpuClockRate,
       guid  = CONFIGDXE_FORM_SET_GUID;
 
     efivarstore CHIPSET_SD_VARSTORE_DATA,
@@ -307,7 +316,19 @@ formset
             option text = STRING_TOKEN(STR_CHIPSET_CLOCK_CPU_NA), value = 0, flags = DEFAULT;
             option text = STRING_TOKEN(STR_CHIPSET_CLOCK_CPU_600MHZ), value = 1, flags = 0;
             option text = STRING_TOKEN(STR_CHIPSET_CLOCK_CPU_MAX), value = 2, flags = 0;
+            option text = STRING_TOKEN(STR_CHIPSET_CLOCK_CPU_CUSTOM), value = 3, flags = 0;
         endoneof;
+
+        grayoutif NOT ideqval CpuClock.Clock == 3;
+          numeric varid = CustomCpuClockRate.Clock,
+              prompt  = STRING_TOKEN(STR_CHIPSET_CUSTOM_CPU_CLOCK_RATE_PROMPT),
+              help    = STRING_TOKEN(STR_CHIPSET_CUSTOM_CPU_CLOCK_RATE_HELP),
+              flags   = DISPLAY_UINT_DEC | NUMERIC_SIZE_4 | INTERACTIVE | RESET_REQUIRED,
+              minimum = 100,
+              maximum = 1600,
+              default = 600,
+          endnumeric;
+        endif;
 
         oneof varid = SdIsArasan.Routing,
             prompt      = STRING_TOKEN(STR_CHIPSET_SD_PROMPT),

--- a/Drivers/RpiFirmwareDxe/RpiFirmwareDxe.c
+++ b/Drivers/RpiFirmwareDxe/RpiFirmwareDxe.c
@@ -805,7 +805,8 @@ EFI_STATUS
 EFIAPI
 RpiFirmwareSetClockRate (
   IN  UINT32 ClockId,
-  IN  UINT32 ClockRate
+  IN  UINT32 ClockRate,
+  IN  UINT32 SkipTurbo
   )
 {
   RPI_FW_SET_CLOCK_RATE_CMD   *Cmd;
@@ -827,6 +828,7 @@ RpiFirmwareSetClockRate (
   Cmd->TagHead.TagValueSize   = 0;
   Cmd->TagBody.ClockId        = ClockId;
   Cmd->TagBody.ClockRate      = ClockRate;
+  Cmd->TagBody.SkipTurbo      = SkipTurbo;
   Cmd->EndTag                 = 0;
 
   Status = MailboxTransaction (Cmd->BufferHead.BufferSize, RPI_FW_MBOX_CHANNEL, &Result);

--- a/Include/Protocol/RaspberryPiFirmware.h
+++ b/Include/Protocol/RaspberryPiFirmware.h
@@ -48,7 +48,8 @@ typedef
 EFI_STATUS
 (EFIAPI *SET_CLOCK_RATE) (
   IN  UINT32    ClockId,
-  OUT UINT32    ClockRate
+  OUT UINT32    ClockRate,
+  IN  UINT32    SkipTurbo
   );
 
 typedef

--- a/RaspberryPiPkg.dec
+++ b/RaspberryPiPkg.dec
@@ -51,14 +51,15 @@
   gRaspberryPiTokenSpaceGuid.PcdHypWindowsDebugHook|0|UINT32|0x0000000b
   gRaspberryPiTokenSpaceGuid.PcdHypWin2000Mask|0|UINT32|0x0000000c
   gRaspberryPiTokenSpaceGuid.PcdCpuClock|0|UINT32|0x0000000d
-  gRaspberryPiTokenSpaceGuid.PcdSdIsArasan|0|UINT32|0x0000000e
-  gRaspberryPiTokenSpaceGuid.PcdMmcForce1Bit|0|UINT32|0x0000000f
-  gRaspberryPiTokenSpaceGuid.PcdMmcForceDefaultSpeed|0|UINT32|0x00000010
-  gRaspberryPiTokenSpaceGuid.PcdMmcSdDefaultSpeedMHz|0|UINT32|0x00000011
-  gRaspberryPiTokenSpaceGuid.PcdMmcSdHighSpeedMHz|0|UINT32|0x00000012
-  gRaspberryPiTokenSpaceGuid.PcdMmcDisableMulti|0|UINT32|0x00000013
-  gRaspberryPiTokenSpaceGuid.PcdDebugEnableJTAG|0|UINT32|0x00000014
-  gRaspberryPiTokenSpaceGuid.PcdDebugShowUEFIExit|0|UINT32|0x00000015
-  gRaspberryPiTokenSpaceGuid.PcdDisplayEnableSShot|0|UINT32|0x00000016
-  gRaspberryPiTokenSpaceGuid.PcdDisplayEnableScaledVModes|0|UINT8|0x00000017
-  gRaspberryPiTokenSpaceGuid.PcdDisplayLogoIndex|0|UINT8|0x00000018
+  gRaspberryPiTokenSpaceGuid.PcdCustomCpuClockRate|0|UINT32|0x0000000e
+  gRaspberryPiTokenSpaceGuid.PcdSdIsArasan|0|UINT32|0x0000000f
+  gRaspberryPiTokenSpaceGuid.PcdMmcForce1Bit|0|UINT32|0x00000010
+  gRaspberryPiTokenSpaceGuid.PcdMmcForceDefaultSpeed|0|UINT32|0x00000011
+  gRaspberryPiTokenSpaceGuid.PcdMmcSdDefaultSpeedMHz|0|UINT32|0x00000012
+  gRaspberryPiTokenSpaceGuid.PcdMmcSdHighSpeedMHz|0|UINT32|0x00000013
+  gRaspberryPiTokenSpaceGuid.PcdMmcDisableMulti|0|UINT32|0x00000014
+  gRaspberryPiTokenSpaceGuid.PcdDebugEnableJTAG|0|UINT32|0x00000015
+  gRaspberryPiTokenSpaceGuid.PcdDebugShowUEFIExit|0|UINT32|0x00000016
+  gRaspberryPiTokenSpaceGuid.PcdDisplayEnableSShot|0|UINT32|0x00000017
+  gRaspberryPiTokenSpaceGuid.PcdDisplayEnableScaledVModes|0|UINT8|0x00000018
+  gRaspberryPiTokenSpaceGuid.PcdDisplayLogoIndex|0|UINT8|0x00000019

--- a/RaspberryPiPkg.dsc
+++ b/RaspberryPiPkg.dsc
@@ -442,6 +442,7 @@ DEFINE HYP_LOG_MASK = 0xffffffff
   #
 
   gRaspberryPiTokenSpaceGuid.PcdCpuClock|L"CpuClock"|gConfigDxeFormSetGuid|0x0|0
+  gRaspberryPiTokenSpaceGuid.PcdCustomCpuClockRate|L"CustomCpuClockRate"|gConfigDxeFormSetGuid|0x0|600
 
   #
   # SD-related.


### PR DESCRIPTION
Note that voltages can't be dynamically changed through the mailbox interface, so if you want to overclock the Pi you'll have to set the "over_voltage" value manually.

"over_voltage=6" should to the trick (for the Pi 3 model B).