### PR TITLE
RPi3: Set the boot option of UEFI Shell as LOAD_OPTION_TYPE_APP

### DIFF
--- a/Library/PlatformBootManagerLib/PlatformBm.c
+++ b/Library/PlatformBootManagerLib/PlatformBm.c
@@ -481,7 +481,7 @@ PlatformRegisterOptionsAndKeys (
   RemoveStaleBootOptions ();
 
   ShellOption = PlatformRegisterFvBootOption (&gUefiShellFileGuid, L"UEFI Shell",
-                                              LOAD_OPTION_ACTIVE);
+                                              LOAD_OPTION_CATEGORY_APP);
   if (ShellOption != -1) {
     //
     // F1 boots Shell.

--- a/readme.md
+++ b/readme.md
@@ -169,12 +169,12 @@ USB keyboard support has been validated with a few keyboards:
 - Microsoft Natural Ergonomic Keyboard 4000
 - An Apple keyboard (chicklet, USB2 hub)
 
-The first time you boot, you will be looking at the UEFI Shell. 'exit'
-and modify the boot order. The boot order will persist across reboots.
+The boot order is SD card first, then USB. You can change it in setup. 
+The boot order will persist across reboots.
 The boot manager will only list devices available to boot from
 (older versions had USB Port 0, USB Port 1, etc).
 
-ESC enters setup. F1 always boots the UEFI Shell.
+ESC enters setup. F1 boots the UEFI Shell.
 
 ![FrontPage](readme1.png)
 


### PR DESCRIPTION
This hides the shell item in boot menu, and therefore boot from USB/SD card by default.
Useful in unattended deployments, like the WoA Deployer.
F1 at startup still boot to UEFI Shell.

Still looking for suggestions for what is the best to do though, maybe keeping the boot item but in the lowest priority.